### PR TITLE
Specified shell does not support all syntax features used in the script

### DIFF
--- a/winbox-setup
+++ b/winbox-setup
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # Winbox Installer
 # What this script does:
 #   1. Downloading wine, wget and unzip, if not installed on the system


### PR DESCRIPTION
The `winbox-install` script specifies `#! /bin/sh` in the first line, but then uses syntax features such as `[[` that are not supported by plain `sh` and are present only in more complex shells. On systems where there is a real `/bin/sh`, and `/bin/sh` is not just a symlink to `/bin/bash` or some other shell, the script therefore fails with a syntax error.