### PR TITLE
Update Arch

### DIFF
--- a/winbox-setup
+++ b/winbox-setup
@@ -47,6 +47,8 @@ depInst() {
       echo "DONE"
     ;;
     'arch' )
+      sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
+      pacman -Sy
       pacman -Sq --noconfirm wine wget curl > /dev/null 2>&1
       echo "DONE"
     ;;


### PR DESCRIPTION
Arch doesn't be default have wine in its repositories, therefore it's necessary to enable multilib repo prior to installing wine.